### PR TITLE
Fixed bug with action buttons

### DIFF
--- a/src/lib/thumb/action_bar.ts
+++ b/src/lib/thumb/action_bar.ts
@@ -110,7 +110,7 @@ function actionButton(action: ActionBarAction, innerHTML: string): string {
 }
 
 function targetOf(event: MouseEvent | TouchEvent): EventTarget | null {
-  if (event instanceof TouchEvent) {
+  if (!(event instanceof MouseEvent)) {
     const touch = event.changedTouches[0];
     return touch === undefined ? null : document.elementFromPoint(touch.clientX, touch.clientY);
   }


### PR DESCRIPTION
The bug was preventing the action buttons from working.
It was caused by if statement of targetOf was throwing an error due to MouseEvent being not defined.
Since event can only ever have one of two valid types simply rearranging the statement causes the desired result without triggering the error.